### PR TITLE
Fix some sprite-related typos and add `fs` dependency to enable local sprites

### DIFF
--- a/getMap.js
+++ b/getMap.js
@@ -2,6 +2,7 @@ const debug = require("debug")("StaticMaps-gl.getMap");
 const genericPool = require("generic-pool");
 const mbgl = require("@mapbox/mapbox-gl-native");
 const request = require("request");
+const fs = require("fs");
 
 mbgl.on("message", function(e) {
   debug("mbgl: ", e);

--- a/mapUtils.js
+++ b/mapUtils.js
@@ -61,7 +61,7 @@ exports.calculateZoom = function(extent, width, height) {
 exports.addOverlayDataToStyle = function(style, overlay) {
   return {
     glyphs: style["glyphs"] || "",
-    sprints: style["sprites"] || "",
+    sprites: style["sprite"] || "",
     sources: {
       ...style["sources"],
       overlay: { type: "geojson", data: overlay }


### PR DESCRIPTION
`staticmaps-gl` still has trouble rendering sprites in Gaia Topo v3, but I am not sure why. These fixes are getting us closer to a solution.